### PR TITLE
Add experimental privilege dropping on Gokrazy

### DIFF
--- a/cmd/consrv/privdrop.go
+++ b/cmd/consrv/privdrop.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"sync"
+)
+
+func newPrivdropCond() *sync.Cond {
+	return sync.NewCond(new(sync.Mutex))
+}
+
+func waitForCond(cond *sync.Cond) {
+	cond.L.Lock()
+	cond.Wait()
+	cond.L.Unlock()
+}

--- a/cmd/consrv/privdrop_gokrazy.go
+++ b/cmd/consrv/privdrop_gokrazy.go
@@ -1,0 +1,45 @@
+//go:build gokrazy
+
+package main
+
+import (
+	"log"
+	"os"
+	"sync"
+	"syscall"
+)
+
+const (
+	PRIVDROP_UID      = 65534 // conventionally: nobody
+	PRIVDROP_GID      = 65534 // conventionally: nogroup
+	CHROOT_PARENT_DIR = "/dev/shm"
+	CHROOT_DIR_PATTERN = "consrv-chroot-*"
+)
+
+func dropPrivileges(cond *sync.Cond, ll *log.Logger) {
+	ll.Printf("droping privileges")
+	chrootDir, err := os.MkdirTemp(CHROOT_PARENT_DIR, CHROOT_DIR_PATTERN)
+	if err != nil {
+		ll.Fatalf("couldn't create an empty directory under %s to chroot into: %v", CHROOT_PARENT_DIR, err)
+	}
+
+	err = syscall.Chroot(chrootDir)
+	if err != nil {
+		ll.Fatalf("couldn't chroot to %s: %v", chrootDir, err)
+	}
+	ll.Printf("chroot'ed into %s", chrootDir)
+
+	err = syscall.Setgid(PRIVDROP_GID)
+	if err != nil {
+		ll.Fatalf("couldn't setgid to %d: %v", PRIVDROP_GID, err)
+	}
+
+	err = syscall.Setuid(PRIVDROP_UID)
+	if err != nil {
+		ll.Fatalf("couldn't setuid to %d: %v", PRIVDROP_UID, err)
+	}
+
+	ll.Printf("changed to uid=%d gid=%d", PRIVDROP_UID, PRIVDROP_GID)
+
+	cond.Broadcast()
+}

--- a/cmd/consrv/privdrop_other.go
+++ b/cmd/consrv/privdrop_other.go
@@ -1,0 +1,12 @@
+//go:build !gokrazy
+
+package main
+
+import (
+	"log"
+	"sync"
+)
+
+func dropPrivileges(_ *sync.Cond, ll *log.Logger) {
+	ll.Printf("Privdrop is not implemented for this platform yet")
+}


### PR DESCRIPTION
Implementation is more involved than NTP's simpler re-execute self and
reuse file descriptor 3 technique. We need privileges to read config
files, open serial port devices, and depending on the port choice of the
user (if <1024) listen on sockets.

Privileged Resource Acquisition Changes:
- Move SSH and debug HTTP server listening socket creation outside of
  goroutines to ensure all the privileged operations are sequentially
  ordered before privdrop.

  - Modify `serveDebug` to receive a net.Listener and call
    `net.http.Server.Serve` instead.

- Use a `sync.Cond` to fence SSH and debug HTTP server goroutines from
  serving before privdrop is done.

Command Line Flag:
- Adds `-experimental-drop-privileges` boolean flag, defaulting to
  false.

Privdrop, when enabled:
- On Gokrazy:
  - Gated behind build constraint tag `gokrazy`
  - Creates an empty directory under /dev/shm and chroot()s to it.
  - Changes GID and UID to conventional nobody/nogroup ID 65534

- Other platforms:
  - Logs a "not implemented for this platform yet" message.
